### PR TITLE
fix: Use TXT instead of ANY to verify existence of domain

### DIFF
--- a/internal/toolbox/toolbox.go
+++ b/internal/toolbox/toolbox.go
@@ -108,7 +108,7 @@ func (s *Service) ValidateDomain(domain string) error {
 	var aError, wwwError bool
 
 	// Check nameserver
-	resultns, err := s.localQuery(domain, dns.TypeANY)
+	resultns, err := s.localQuery(domain, dns.TypeTXT)
 	if err != nil {
 		// no name server to answer the question
 		// disable return err here


### PR DESCRIPTION
"ANY" is the most expensive DNS 'record' to lookup according to [0], and Cloudflare has disabled responding to those queries and responds with 'NOTIMP' (not implemented?).

A DNS server will respond to TXT even if there are no TXT records for the domain, so that can be used "just as well" as "ANY" to verify that the domain exists. It is, of course, also possible to use A/AAAA queries for this purpose.

ANY query with dig(1) on @1.1.1.1:
```
$ dig ANY netbox.infra.gathering.org @1.1.1.1

; <<>> DiG 9.10.6 <<>> ANY netbox.infra.gathering.org @1.1.1.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOTIMP, id: 60473
*snip*
```

ANY query with dig(1) on @8.8.8.8:
```
$ dig ANY netbox.infra.gathering.org @8.8.8.8

; <<>> DiG 9.10.6 <<>> ANY netbox.infra.gathering.org @8.8.8.8
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 524
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
*snip*
```

[0]: https://blog.cloudflare.com/deprecating-dns-any-meta-query-type/

[0]: https://blog.cloudflare.com/deprecating-dns-any-meta-query-type/